### PR TITLE
Add JSON Schema form generator package

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
   <a href="#-what-is-mcp-ui">What's mcp-ui?</a> •
   <a href="#-installation">Installation</a> •
   <a href="#-quickstart">Quickstart</a> •
+  <a href="#-json-schema-generator">JSON Schema Generator</a> •
   <a href="#-core-concepts">Core Concepts</a> •
   <a href="#-examples">Examples</a> •
   <a href="#-roadmap">Roadmap</a> •
@@ -127,6 +128,27 @@ yarn add @mcp-ui/server @mcp-ui/client
    ```
 
 3. **Enjoy** interactive MCP UIs — no extra configuration required.
+## 🧩 JSON Schema Generator
+
+Generate simple React forms from JSON Schema using the `generateUI` API.
+
+```tsx
+import { generateUI } from "@mcp-ui/generator";
+
+const schema = {
+  type: "object",
+  properties: {
+    name: { type: "string" },
+    age: { type: "number" },
+    color: { type: "string", enum: ["red", "green"] },
+  },
+};
+
+export default function MyForm() {
+  return generateUI(schema);
+}
+```
+
 
 ## 🌍 Examples
 

--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@mcp-ui/generator",
+  "version": "0.1.0",
+  "private": false,
+  "description": "Generate React forms from JSON Schema",
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "dependencies": {
+    "react": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.0",
+    "typescript": "^5.0.0",
+    "vite": "^5.0.0",
+    "vite-plugin-dts": "^3.6.0",
+    "vitest": "^1.0.0",
+    "@testing-library/react": "^14.0.0",
+    "@testing-library/jest-dom": "^6.0.0",
+    "jsdom": "^22.0.0"
+  },
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "test": "vitest run",
+    "test:watch": "vitest watch",
+    "lint": "eslint . --ext .ts,.tsx"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "license": "Apache-2.0"
+}

--- a/packages/generator/src/__tests__/generateUI.test.tsx
+++ b/packages/generator/src/__tests__/generateUI.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import React from 'react';
+import { generateUI, JSONSchema } from '../index.js';
+
+describe('generateUI', () => {
+  const schema: JSONSchema = {
+    type: 'object',
+    properties: {
+      name: { type: 'string', title: 'Name' },
+      age: { type: 'number', title: 'Age' },
+      color: { type: 'string', enum: ['red', 'green'], title: 'Color' },
+    },
+  };
+
+  it('renders form fields based on schema', () => {
+    render(generateUI(schema));
+
+    expect(screen.getByLabelText('Name')).toBeInTheDocument();
+    expect(screen.getByLabelText('Age')).toBeInTheDocument();
+    expect(screen.getByLabelText('Color')).toBeInTheDocument();
+  });
+
+  it('updates value on user input', () => {
+    render(generateUI(schema));
+
+    const nameInput = screen.getByLabelText('Name') as HTMLInputElement;
+    fireEvent.change(nameInput, { target: { value: 'Alice' } });
+    expect(nameInput.value).toBe('Alice');
+
+    const ageInput = screen.getByLabelText('Age') as HTMLInputElement;
+    fireEvent.change(ageInput, { target: { value: '30' } });
+    expect(ageInput.value).toBe('30');
+
+    const colorSelect = screen.getByLabelText('Color') as HTMLSelectElement;
+    fireEvent.change(colorSelect, { target: { value: 'green' } });
+    expect(colorSelect.value).toBe('green');
+  });
+});

--- a/packages/generator/src/index.tsx
+++ b/packages/generator/src/index.tsx
@@ -1,0 +1,88 @@
+import React, { useState } from 'react';
+
+export interface JSONSchemaProperty {
+  type: string;
+  enum?: (string | number)[];
+  title?: string;
+}
+
+export interface JSONSchema {
+  type: 'object';
+  properties: Record<string, JSONSchemaProperty>;
+  required?: string[];
+}
+
+interface GeneratedFormProps {
+  schema: JSONSchema;
+}
+
+const GeneratedForm: React.FC<GeneratedFormProps> = ({ schema }) => {
+  const { properties } = schema;
+  const [formData, setFormData] = useState<Record<string, unknown>>({});
+
+  const handleChange = (key: string, value: unknown) => {
+    setFormData((prev) => ({ ...prev, [key]: value }));
+  };
+
+  const renderField = (key: string, prop: JSONSchemaProperty) => {
+    if (prop.enum) {
+      return (
+        <select
+          data-testid={`${key}-select`}
+          value={(formData[key] as string | undefined) ?? ''}
+          onChange={(e) => handleChange(key, e.target.value)}
+        >
+          <option value="">Select {key}</option>
+          {prop.enum.map((option) => (
+            <option key={String(option)} value={String(option)}>
+              {String(option)}
+            </option>
+          ))}
+        </select>
+      );
+    }
+
+    switch (prop.type) {
+      case 'string':
+        return (
+          <input
+            data-testid={`${key}-input`}
+            type="text"
+            value={(formData[key] as string | undefined) ?? ''}
+            onChange={(e) => handleChange(key, e.target.value)}
+          />
+        );
+      case 'number':
+      case 'integer':
+        return (
+          <input
+            data-testid={`${key}-input`}
+            type="number"
+            value={formData[key] ?? ''}
+            onChange={(e) => handleChange(key, Number(e.target.value))}
+          />
+        );
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <form>
+      {Object.entries(properties).map(([key, prop]) => (
+        <div key={key}>
+          <label>
+            {prop.title || key}
+            {renderField(key, prop)}
+          </label>
+        </div>
+      ))}
+    </form>
+  );
+};
+
+export const generateUI = (schema: JSONSchema): React.ReactElement => {
+  return <GeneratedForm schema={schema} />;
+};
+
+export { GeneratedForm };

--- a/packages/generator/tsconfig.json
+++ b/packages/generator/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist", "src/__tests__"]
+}

--- a/packages/generator/vite.config.ts
+++ b/packages/generator/vite.config.ts
@@ -1,0 +1,25 @@
+import { defineConfig } from 'vite';
+import dts from 'vite-plugin-dts';
+import react from '@vitejs/plugin-react-swc';
+import path from 'path';
+
+export default defineConfig({
+  plugins: [
+    react(),
+    dts({
+      insertTypesEntry: true,
+      tsconfigPath: path.resolve(__dirname, 'tsconfig.json'),
+      exclude: ['**/__tests__/**', '**/*.test.ts', '**/*.spec.ts'],
+    }),
+  ],
+  build: {
+    lib: {
+      entry: path.resolve(__dirname, 'src/index.ts'),
+      name: 'McpUiGenerator',
+      formats: ['es', 'umd'],
+      fileName: (format) =>
+        `index.${format === 'es' ? 'mjs' : format === 'umd' ? 'js' : format + '.js'}`,
+    },
+    sourcemap: true,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -142,6 +142,37 @@ importers:
         specifier: ^1.0.0
         version: 1.6.1(@types/node@22.15.18)(jsdom@22.1.0)
 
+  packages/generator:
+    dependencies:
+      react:
+        specifier: ^18.2.0
+        version: 18.3.1
+    devDependencies:
+      '@testing-library/jest-dom':
+        specifier: ^6.0.0
+        version: 6.6.3
+      '@testing-library/react':
+        specifier: ^14.0.0
+        version: 14.3.1(@types/react@18.3.21)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@types/react':
+        specifier: ^18.2.0
+        version: 18.3.21
+      jsdom:
+        specifier: ^22.0.0
+        version: 22.1.0
+      typescript:
+        specifier: ^5.0.0
+        version: 5.8.3
+      vite:
+        specifier: ^5.0.0
+        version: 5.4.19(@types/node@22.15.18)
+      vite-plugin-dts:
+        specifier: ^3.6.0
+        version: 3.9.1(@types/node@22.15.18)(rollup@4.40.2)(typescript@5.8.3)(vite@5.4.19(@types/node@22.15.18))
+      vitest:
+        specifier: ^1.0.0
+        version: 1.6.1(@types/node@22.15.18)(jsdom@22.1.0)
+
   packages/server:
     devDependencies:
       '@types/node':


### PR DESCRIPTION
## Summary
- add `@mcp-ui/generator` package for turning JSON Schemas into forms
- support text, number and select fields
- document generator usage in README
- provide vitest unit tests

## Testing
- `pnpm exec vitest run`

------
https://chatgpt.com/codex/tasks/task_e_684455e0b354832f89abff9fd187fc48